### PR TITLE
Optimize title bar cropping

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -15,13 +15,7 @@ use windows::{
             D3D11_MAPPED_SUBRESOURCE, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING, ID3D11Device,
             ID3D11DeviceContext, ID3D11Texture2D,
         },
-        Dwm::{DWMWA_EXTENDED_FRAME_BOUNDS, DwmGetWindowAttribute},
         Dxgi::Common::{DXGI_FORMAT, DXGI_SAMPLE_DESC},
-        Gdi::ClientToScreen,
-    },
-    Win32::{
-        Foundation::{HWND, POINT, RECT},
-        UI::{HiDpi::GetDpiForWindow, WindowsAndMessaging::GetClientRect},
     },
 };
 
@@ -74,6 +68,7 @@ pub struct Frame<'a> {
     height: u32,
     color_format: ColorFormat,
     exclude_title_bar: bool,
+    title_bar_height: u32,
     window: Option<Window>,
 }
 
@@ -109,6 +104,7 @@ impl<'a> Frame<'a> {
         height: u32,
         color_format: ColorFormat,
         exclude_title_bar: bool,
+        title_bar_height: u32,
         window: Option<Window>,
     ) -> Self {
         Self {
@@ -122,6 +118,7 @@ impl<'a> Frame<'a> {
             height,
             color_format,
             exclude_title_bar,
+            title_bar_height,
             window,
         }
     }
@@ -205,41 +202,12 @@ impl<'a> Frame<'a> {
     /// The FrameBuffer containing the frame data.
     #[inline]
     pub fn buffer(&mut self) -> Result<FrameBuffer, Error> {
-        if self.exclude_title_bar && self.window.as_ref().map_or(false, |w| w.is_valid()) {
-            let hwnd: HWND = HWND(self.window.as_ref().unwrap().as_raw_hwnd());
-
-            let mut window_rect = RECT::default();
-            let mut client_rect = RECT::default();
-
-            unsafe {
-                let _ = DwmGetWindowAttribute(
-                    hwnd,
-                    DWMWA_EXTENDED_FRAME_BOUNDS, // Use with DwmGetWindowAttribute. Retrieves the extended frame bounds rectangle in *screen space*. The retrieved value is of type RECT. https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
-                    &mut window_rect as *mut _ as *mut _,
-                    std::mem::size_of::<RECT>() as u32,
-                );
-                let _ = GetClientRect(hwnd, &mut client_rect);
-            }
-
-            let mut client_point = POINT { x: 0, y: 0 };
-            unsafe {
-                let _ = ClientToScreen(hwnd, &mut client_point);
-            }
-
-            let window_hight = window_rect.bottom - window_rect.top;
-
-            let dpi = unsafe { GetDpiForWindow(hwnd) };
-
-            let client_hight = (client_rect.bottom - client_rect.top) * dpi as i32 / 96;
-
-            let actual_title_height = (window_hight - client_hight) as i32;
-
-            if actual_title_height > 0 {
-                let top_offset_u32 = actual_title_height as u32;
-                if self.height > top_offset_u32 {
-                    return self.buffer_crop(0, top_offset_u32, self.width, self.height);
-                }
-            }
+        if self.exclude_title_bar
+            && self.window.as_ref().map_or(false, |w| w.is_valid())
+            && self.title_bar_height > 0
+            && self.height > self.title_bar_height
+        {
+            return self.buffer_crop(0, self.title_bar_height, self.width, self.height);
         }
 
         // Texture Settings

--- a/src/graphics_capture_api.rs
+++ b/src/graphics_capture_api.rs
@@ -148,6 +148,16 @@ impl GraphicsCaptureApi {
             return Err(Error::BorderConfigUnsupported);
         }
 
+        // Pre-calculate the title bar height so each frame doesn't need to do it
+        let title_bar_height = if exclude_title_bar {
+            window
+                .as_ref()
+                .and_then(Window::title_bar_height)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
         // Create DirectX devices
         let direct3d_device = create_direct3d_device(&d3d_device)?;
 
@@ -212,6 +222,7 @@ impl GraphicsCaptureApi {
             let direct3d_device_recreate = SendDirectX::new(direct3d_device.clone());
             // Capture exclude_title_bar for the closure
             let exclude_title_bar_for_closure = exclude_title_bar;
+            let title_bar_height_for_closure = title_bar_height;
 
             move |frame, _| {
                 // Return early if the capture is closed
@@ -274,6 +285,7 @@ impl GraphicsCaptureApi {
                     texture_height,
                     color_format,
                     exclude_title_bar_for_closure,
+                    title_bar_height_for_closure,
                     window,
                 );
 


### PR DESCRIPTION
## Summary
- cache window title bar height once per capture
- simplify Frame cropping logic to use the cached height
- expose `Window::title_bar_height` helper

## Testing
- `cargo test` *(fails: could not download file)*
- `cargo fmt` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_b_683d9d7284b483329e14bb91bf7e4f04